### PR TITLE
Allow sorting of translation strings

### DIFF
--- a/config/laravel-translatable-string-exporter.php
+++ b/config/laravel-translatable-string-exporter.php
@@ -3,24 +3,24 @@ return [
     // Directories to search in.
     'directories'=> [
         'app',
-        'resources'
+        'resources',
     ],
 
     // File Patterns to search for.
     'patterns'=> [
         '*.php',
-        '*.js'
+        '*.js',
     ],
 
     // Translation function names.
-    // If your function name contains $ escape it using \$
+    // If your function name contains $ escape it using \$ .
     'functions'=> [
         '__',
         '_t',
-        '@lang'
+        '@lang',
     ],
 
-    // Indicates if we need to sort the translation keys
-    // It might be useful to find translations and detect duplications
+    // Indicates weather you need to sort the translations alphabetically by original strings.
+    // Helps navigate a translation file and detect possible duplicates.
     'sort-keys' => false,
 ];

--- a/config/laravel-translatable-string-exporter.php
+++ b/config/laravel-translatable-string-exporter.php
@@ -18,5 +18,9 @@ return [
         '__',
         '_t',
         '@lang'
-   ]
+    ],
+
+    // Indicates if we need to sort the translation keys
+    // It might be useful to find translations and detect duplications
+    'sort-keys' => false,
 ];

--- a/config/laravel-translatable-string-exporter.php
+++ b/config/laravel-translatable-string-exporter.php
@@ -20,7 +20,8 @@ return [
         '@lang',
     ],
 
-    // Indicates weather you need to sort the translations alphabetically by original strings.
-    // Helps navigate a translation file and detect possible duplicates.
+    // Indicates weather you need to sort the translations alphabetically 
+    // by original strings (keys).
+    // It helps navigate a translation file and detect possible duplicates.
     'sort-keys' => false,
 ];

--- a/src/Core/Exporter.php
+++ b/src/Core/Exporter.php
@@ -47,8 +47,11 @@ class Exporter
         // Merge old an new translations. We don't override old strings to preserve existing translations.
         $resulting_strings = $this->mergeStrings($new_strings, $existing_strings);
 
+        // Sort the translations, if the option is enabled
+        $sorted_strings = $this->sortIfEnabled($resulting_strings);
+
         // Prepare JSON string and dump it to the translation file.
-        $content = $this->jsonEncode($resulting_strings);
+        $content = $this->jsonEncode($sorted_strings);
         IO::write($content, $path);
     }
 
@@ -98,5 +101,22 @@ class Exporter
     protected function mergeStrings($new_strings, $existing_strings)
     {
         return array_intersect_key(array_merge($new_strings, $existing_strings), $new_strings);
+    }
+
+    /**
+     * Sort the translation strings, if enabled from the configs
+     *
+     * @param array $strings
+     * @return array
+     */
+    protected function sortIfEnabled($strings)
+    {
+        if (config('laravel-translatable-string-exporter.sort-keys', false)) {
+            return array_sort($strings, function ($value, $key) {
+                return strtolower($key);
+            });
+        }
+
+        return $strings;
     }
 }

--- a/src/Core/Exporter.php
+++ b/src/Core/Exporter.php
@@ -104,7 +104,7 @@ class Exporter
     }
 
     /**
-     * Sort the translation strings alphabetically by the original string 
+     * Sort the translation strings alphabetically by their original strings (keys) 
      * if the corresponding option is enabled through the package config.
      *
      * @param array $strings

--- a/src/Core/Exporter.php
+++ b/src/Core/Exporter.php
@@ -58,7 +58,8 @@ class Exporter
      * @param $strings
      * @return string
      */
-    protected function jsonEncode($strings) {
+    protected function jsonEncode($strings)
+    {
         return json_encode($strings, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
     }
 
@@ -68,7 +69,8 @@ class Exporter
      * @param string $string
      * @return array
      */
-    protected function jsonDecode($string) {
+    protected function jsonDecode($string)
+    {
         return (array) json_decode($string);
     }
 
@@ -79,7 +81,8 @@ class Exporter
      * @param string $language
      * @return string
      */
-    protected function getExportPath($base_path, $language) {
+    protected function getExportPath($base_path, $language)
+    {
         return $base_path . DIRECTORY_SEPARATOR .
             $this->directory . DIRECTORY_SEPARATOR . $language . '.json';
     }
@@ -92,7 +95,8 @@ class Exporter
      * @param array $new_strings
      * @return string
      */
-    protected function mergeStrings($new_strings, $existing_strings) {
-        return (object) array_intersect_key(array_merge($new_strings, $existing_strings), $new_strings);
+    protected function mergeStrings($new_strings, $existing_strings)
+    {
+        return array_intersect_key(array_merge($new_strings, $existing_strings), $new_strings);
     }
 }

--- a/src/Core/Exporter.php
+++ b/src/Core/Exporter.php
@@ -47,7 +47,7 @@ class Exporter
         // Merge old an new translations. We don't override old strings to preserve existing translations.
         $resulting_strings = $this->mergeStrings($new_strings, $existing_strings);
 
-        // Sort the translations, if the option is enabled
+        // Sort the translations if enabled through the config.
         $sorted_strings = $this->sortIfEnabled($resulting_strings);
 
         // Prepare JSON string and dump it to the translation file.
@@ -104,7 +104,8 @@ class Exporter
     }
 
     /**
-     * Sort the translation strings, if enabled from the configs
+     * Sort the translation strings alphabetically by the original string 
+     * if the corresponding option is enabled through the package config.
      *
      * @param array $strings
      * @return array


### PR DESCRIPTION
This pull request enables users to set an option in the config to enable sorting of the language strings.
This allows for easier maintainability of the file, finding duplications and so on.

By default the feature is disabled, from the config, so the users won't receive unnecessary changes in their lang files when they update.