### PR TITLE
Allow users to specify multiple languages to export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # Translatable String Exporter for Laravel >= 5.4
+
 As we know, Laravel 5.4 has introduced a "new" way of string translation.
 Now you can use `__('Translate me')` or `@lang('Translate me')` with translations in JSON files to translate strings.
 Translatable String Exporter is aimed to collect all translatable strings of an application and create corresponding translation files in JSON format to simplify the process of translation.
 
 ## Installation
 
-1) Add kkomelin/laravel-translatable-string-exporter to your project:
+1. Add kkomelin/laravel-translatable-string-exporter to your project:
 
 ```bash
 composer require kkomelin/laravel-translatable-string-exporter
 ```
 
-2) For **Laravel >= 5.5** we use Package Auto-Discovery, so you may skip this step.  
-For **Laravel < 5.5**, add `ExporterServiceProvider` to the providers array in config/app.php:
+2. For **Laravel >= 5.5** we use Package Auto-Discovery, so you may skip this step.
+   For **Laravel < 5.5**, add `ExporterServiceProvider` to the providers array in config/app.php:
 
 ```php
 KKomelin\TranslatableStringExporter\Providers\ExporterServiceProvider::class,
@@ -31,7 +32,8 @@ php artisan vendor:publish --provider="KKomelin\TranslatableStringExporter\Provi
 ```bash
 php artisan translatable:export <lang>
 ```
-Where `<lang>` is a language code, for example "es".
+
+Where `<lang>` is a language code, for example "es". You can also provide multiple languages to export to at once, separating their codes with comas "es,en,bg".
 
 The command with the "es" parameter will create es.json file in the `resources/lang` folder of your project.
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,14 @@ php artisan vendor:publish --provider="KKomelin\TranslatableStringExporter\Provi
 php artisan translatable:export <lang>
 ```
 
-Where `<lang>` is a language code, for example "es". You can also provide multiple languages to export to at once, separating their codes with comas "es,en,bg".
+Where `<lang>` is a language code or a comma-separated list of language codes.  
+For example:
+```bash
+php artisan translatable:export es
+php artisan translatable:export es,bg,de
+```
 
-The command with the "es" parameter will create es.json file in the `resources/lang` folder of your project.
+The command with the "es,bg,de" parameter passed will create es.json, bg.json, de.json files with translatable strings in the `resources/lang` folder of your project or update the existing files.
 
 ## License & Copyright
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ php artisan translatable:export es
 php artisan translatable:export es,bg,de
 ```
 
-The command with the "es,bg,de" parameter passed will create es.json, bg.json, de.json files with translatable strings in the `resources/lang` folder of your project or update the existing files.
+The command with the "es,bg,de" parameter passed will create es.json, bg.json, de.json files with translatable strings or update the existing files in the `resources/lang` folder of your project.
 
 ## License & Copyright
 

--- a/src/Console/ExportCommand.php
+++ b/src/Console/ExportCommand.php
@@ -6,7 +6,8 @@ use KKomelin\TranslatableStringExporter\Core\Exporter;
 use KKomelin\TranslatableStringExporter\Core\Extractor;
 use Symfony\Component\Console\Input\InputArgument;
 
-class ExportCommand extends Command {
+class ExportCommand extends Command
+{
 
     /**
      * The console command name.
@@ -36,7 +37,7 @@ class ExportCommand extends Command {
     public function __construct(Exporter $exporter)
     {
         parent::__construct();
-        
+
         $this->exporter = $exporter;
     }
 
@@ -59,11 +60,13 @@ class ExportCommand extends Command {
      */
     public function handle()
     {
-        $language = $this->argument('lang');
+        $languages = explode(',', $this->argument('lang'));
 
-        $this->exporter->export(base_path(), $language);
+        foreach ($languages as $language) {
+            $this->exporter->export(base_path(), $language);
 
-        $this->info('Translatable strings have been extracted and written to the ' . $language . '.json file.');
+            $this->info('Translatable strings have been extracted and written to the ' . $language . '.json file.');
+        }
     }
 
     /**
@@ -73,8 +76,12 @@ class ExportCommand extends Command {
      */
     protected function getArguments()
     {
-        return array(
-            array('lang', InputArgument::REQUIRED, 'A language code for which the translatable strings are extracted, e.g. "es".'),
-        );
+        return [
+            [
+                'lang',
+                InputArgument::REQUIRED,
+                'A language code or codes for which the translatable strings are extracted, e.g. "es" or "es,en,bg".'
+            ],
+        ];
     }
 }

--- a/src/Console/ExportCommand.php
+++ b/src/Console/ExportCommand.php
@@ -80,7 +80,7 @@ class ExportCommand extends Command
             [
                 'lang',
                 InputArgument::REQUIRED,
-                'A language code or codes for which the translatable strings are extracted, e.g. "es" or "es,en,bg".'
+                'A language code or a comma-separated list of language codes for which the translatable strings are extracted, e.g. "es" or "es,bg,de".'
             ],
         ];
     }


### PR DESCRIPTION
Users can pass a comma-separated list of languages to export the translations in.
This way they might run the command only once for all languages instead of once for each language.

Backward compatibility is preserved and the packages will work with one language as before.