### PR TITLE
Persistent strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,32 @@ php artisan translatable:export es,bg,de
 
 The command with the "es,bg,de" parameter passed will create es.json, bg.json, de.json files with translatable strings or update the existing files in the `resources/lang` folder of your project.
 
+### Persistent strings
+
+Some strings are not included in the export, because they are being dynamically generated. For example:
+
+```{{ __(sprintf('Dear :name, your order has been %s', $orderStatus)) }}```
+
+Where `$orderStatus` can be 'approved', 'paid', 'cancelled' and so on.
+
+In this case, you can add the strings to the `<lang>.json` file manually. For example:
+
+```
+  "Dear :name, your order has been approved": "Dear :name, your order has been approved",
+  "Dear :name, your order has been paid": "Dear :name, your order has been paid",
+  ...
+```
+
+In order for those, manually added, strings not to get removed the next time you run the export command, you should add them to a json file named `persistent-strings.json`. For example:
+```
+[
+  "Dear :name, your order has been approved",
+  "Dear :name, your order has been paid",
+  ...
+]
+```
+     
+
 ## License & Copyright
 
 MIT, (c) 2018 Konstantin Komelin

--- a/README.md
+++ b/README.md
@@ -46,23 +46,23 @@ The command with the "es,bg,de" parameter passed will create es.json, bg.json, d
 
 Some strings are not included in the export, because they are being dynamically generated. For example:
 
-```{{ __(sprintf('Dear :name, your order has been %s', $orderStatus)) }}```
+```{{ __(sprintf('Dear customer, your order has been %s', $orderStatus)) }}```
 
 Where `$orderStatus` can be 'approved', 'paid', 'cancelled' and so on.
 
 In this case, you can add the strings to the `<lang>.json` file manually. For example:
 
 ```
-  "Dear :name, your order has been approved": "Dear :name, your order has been approved",
-  "Dear :name, your order has been paid": "Dear :name, your order has been paid",
+  "Dear customer, your order has been approved": "Dear customer, your order has been approved",
+  "Dear customer, your order has been paid": "Dear customer, your order has been paid",
   ...
 ```
 
 In order for those, manually added, strings not to get removed the next time you run the export command, you should add them to a json file named `persistent-strings.json`. For example:
 ```
 [
-  "Dear :name, your order has been approved",
-  "Dear :name, your order has been paid",
+  "Dear customer, your order has been approved",
+  "Dear customer, your order has been paid",
   ...
 ]
 ```

--- a/src/Core/Exporter.php
+++ b/src/Core/Exporter.php
@@ -7,9 +7,16 @@ class Exporter
     /**
      * The target directory for translation files.
      *
-     * @var array
+     * @var string
      */
     protected $directory = 'resources/lang';
+
+    /**
+     * The filename without extension for persistent strings.
+     *
+     * @var string
+     */
+    const PERSISTENT_STRINGS_FILENAME_WO_EXT = 'persistent-strings';
 
     /**
      * Extractor object.
@@ -44,12 +51,12 @@ class Exporter
         $content = IO::read($language_path);
         $existing_strings = $this->jsonDecode($content);
 
-        // Get the persistent strings
-        $persistent_strings_path = $this->getExportPath($base_path, 'persistent-strings');
+        // Get the persistent strings.
+        $persistent_strings_path = $this->getExportPath($base_path, self::PERSISTENT_STRINGS_FILENAME_WO_EXT);
         $persistent_content = IO::read($persistent_strings_path);
         $persistent_strings = $this->jsonDecode($persistent_content);
 
-        // Merge old an new translations. We don't override old strings to preserve existing translations.
+        // Merge old an new translations preserving existing translations and persistent strings.
         $resulting_strings = $this->mergeStrings($new_strings, $existing_strings, $persistent_strings);
 
         // Sort the translations if enabled through the config.
@@ -96,13 +103,12 @@ class Exporter
     }
 
     /**
-     * Merge two arrays of translations and convert the resulting array to object.
-     * We don't override old strings to preserve existing translations.
+     * Merge two arrays of translations preserving existing translations and persistent strings.
      *
      * @param array $existing_strings
      * @param array $new_strings
      * @param array $persistent_strings
-     * @return string
+     * @return array
      */
     protected function mergeStrings($new_strings, $existing_strings, $persistent_strings)
     {

--- a/src/Core/Exporter.php
+++ b/src/Core/Exporter.php
@@ -17,7 +17,7 @@ class Exporter
      * @var string
      */
     protected $directory = 'resources/lang';
-    
+
     /**
      * Extractor object.
      *
@@ -113,9 +113,9 @@ class Exporter
     protected function mergeStrings($new_strings, $existing_strings, $persistent_strings)
     {
         $merged_strings = array_merge($new_strings, $existing_strings);
-        return array_filter($merged_strings, function ($key) use ($persistent_strings, $new_strings) {
+        return $this->arrayFilterByKey($merged_strings, function ($key) use ($persistent_strings, $new_strings) {
             return in_array($key, $persistent_strings) || array_key_exists($key, $new_strings);
-        }, ARRAY_FILTER_USE_KEY);
+        });
     }
 
     /**
@@ -134,5 +134,28 @@ class Exporter
         }
 
         return $strings;
+    }
+
+    /**
+     * Filtering an array by its keys using a callback.
+     * Supports PHP < 5.6.0. Use array_filter($array, $callback, ARRAY_FILTER_USE_KEY) instead
+     * if you don't need to support earlier versions.
+     *
+     * The code borrowed from https://gist.github.com/h4cc/8e2e3d0f6a8cd9cacde8
+     *
+     * @deprecated 2.0.0 Replace with array_filter($array, $callback, ARRAY_FILTER_USE_KEY) when drop PHP < 5.6 support.
+     *
+     * @param array $array
+     *  The array to iterate over.
+     * @param callable $callback
+     *  The callback function to use.
+     *
+     * @return array
+     *  The filtered array.
+     */
+    private function arrayFilterByKey($array, $callback)
+    {
+        $matchedKeys = array_filter(array_keys($array), $callback);
+        return array_intersect_key($array, array_flip($matchedKeys));
     }
 }

--- a/src/Core/Exporter.php
+++ b/src/Core/Exporter.php
@@ -5,19 +5,19 @@ namespace KKomelin\TranslatableStringExporter\Core;
 class Exporter
 {
     /**
-     * The target directory for translation files.
-     *
-     * @var string
-     */
-    protected $directory = 'resources/lang';
-
-    /**
      * The filename without extension for persistent strings.
      *
      * @var string
      */
     const PERSISTENT_STRINGS_FILENAME_WO_EXT = 'persistent-strings';
 
+    /**
+     * The target directory for translation files.
+     *
+     * @var string
+     */
+    protected $directory = 'resources/lang';
+    
     /**
      * Extractor object.
      *

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -139,4 +139,46 @@ class ExporterTest extends BaseTestCase
 
         $this->assertEquals($expected, $actual);
     }
+
+    public function testPersistentTranslations()
+    {
+        $this->cleanLangsFolder();
+
+        // 1. Create a translation file ourselves.
+
+        $existing_translations = [
+            'name1_en' => 'name1_es',
+            'name2_en' => 'name2_es',
+            'name3_en' => 'name3_es',
+        ];
+
+        $content = json_encode($existing_translations);
+
+        $this->writeToTranslationFile('es', $content);
+
+        // 2. Create a file with the keys of any strings which should persist even if they are not contained in the views.
+
+        $persistentContent = json_encode(['name2_en']);
+        $this->writeToTranslationFile('persistent-strings', $persistentContent);
+
+        // 3. Create a test view only containing one of the non-persistent strings, and a new string.
+
+        $this->createTestView("{{ Existing string: __('name1_en') New string: __('name4_en') }}");
+
+        $this->artisan('translatable:export', ['lang' => 'es'])
+            ->expectsOutput('Translatable strings have been extracted and written to the es.json file.')
+            ->assertExitCode(0);
+
+        $actual = $this->getTranslationFileContent('es');
+
+        // The missing, non-persistent, strings should be removed. The rest should remain.
+
+        $expected = [
+            'name1_en' => 'name1_es',
+            'name2_en' => 'name2_es',
+            'name4_en' => 'name4_en',
+        ];
+
+        $this->assertEquals($expected, $actual);
+    }
 }

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests;
 
+use KKomelin\TranslatableStringExporter\Core\Exporter;
+
 class ExporterTest extends BaseTestCase
 {
     public function testTranslationFilesCreation()
@@ -159,7 +161,7 @@ class ExporterTest extends BaseTestCase
         // 2. Create a file with the keys of any strings which should persist even if they are not contained in the views.
 
         $persistentContent = json_encode(['name2_en']);
-        $this->writeToTranslationFile('persistent-strings', $persistentContent);
+        $this->writeToTranslationFile(Exporter::PERSISTENT_STRINGS_FILENAME_WO_EXT, $persistentContent);
 
         // 3. Create a test view only containing one of the non-persistent strings, and a new string.
 


### PR DESCRIPTION
Sometimes, translatable strings are not detectable in the source files (e.g. strings that are programmatically generated).

Even if one would add these strings to the `<lang>.json` file manually, they would still be removed during the next export.

To prevent that from happening, one should add these strings to a new file named `persistent-strings.json`.