### PR TITLE
added patterns option to export command

### DIFF
--- a/src/Console/ExportCommand.php
+++ b/src/Console/ExportCommand.php
@@ -2,9 +2,10 @@
 namespace KKomelin\TranslatableStringExporter\Console;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
 use KKomelin\TranslatableStringExporter\Core\Exporter;
 use KKomelin\TranslatableStringExporter\Core\StringExtractor;
-use Symfony\Component\Console\Input\InputArgument;
 
 class ExportCommand extends Command
 {
@@ -61,9 +62,14 @@ class ExportCommand extends Command
     public function handle()
     {
         $languages = explode(',', $this->argument('lang'));
+        $patterns = null;
+
+        if($this->option('patterns')) {
+            $patterns = explode(',', $this->option('patterns'));
+        }
 
         foreach ($languages as $language) {
-            $this->exporter->export(base_path(), $language);
+            $this->exporter->export(base_path(), $language, $patterns);
 
             $this->info('Translatable strings have been extracted and written to the ' . $language . '.json file.');
         }
@@ -81,7 +87,24 @@ class ExportCommand extends Command
                 'lang',
                 InputArgument::REQUIRED,
                 'A language code or a comma-separated list of language codes for which the translatable strings are extracted, e.g. "es" or "es,bg,de".'
-            ],
+            ]
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            [
+                'patterns',
+                'p',
+                InputOption::VALUE_OPTIONAL,
+                'Override the default patterns and use the given instead, e.g. --patterns="*.php,*.js".'
+            ]
         ];
     }
 }

--- a/src/Core/Exporter.php
+++ b/src/Core/Exporter.php
@@ -35,14 +35,15 @@ class Exporter
      *
      * @param string $base_path
      * @param string $language
+     * @param array  $patterns
      * @return array
      */
-    public function export($base_path, $language)
+    public function export($base_path, $language, array $patterns=null)
     {
         $language_path = IO::languageFilePath($base_path, $language);
 
         // Extract source strings from the project directories.
-        $new_strings = $this->extractor->extract();
+        $new_strings = $this->extractor->extract($patterns);
 
         // Read existing translation file for the chosen language.
         $existing_strings = IO::readTranslationFile($language_path);

--- a/src/Core/FileFinder.php
+++ b/src/Core/FileFinder.php
@@ -36,6 +36,16 @@ class FileFinder
     }
 
     /**
+     * Override the default patterns
+     * 
+     * @param array $patterns
+     */
+    public function setPatterns(array $patterns)
+    {
+        $this->patterns = $patterns;
+    }
+
+    /**
      * Find all files that can contain translatable strings.
      *
      * @return \Symfony\Component\Finder\Finder|null

--- a/src/Core/StringExtractor.php
+++ b/src/Core/StringExtractor.php
@@ -15,8 +15,14 @@ class StringExtractor
 
     /**
      * Extract translatable strings from the project files.
+     * 
+     * @param array $patterns
      */
-    public function extract() {
+    public function extract(array $patterns=null) {
+
+        if($patterns) {
+            $this->finder->setPatterns($patterns);
+        }
 
         $strings = [];
 

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -43,6 +43,11 @@ class BaseTestCase extends TestCase
         file_put_contents(resource_path('views/index.blade.php'), $content);
     }
 
+    protected function createTestTypescript($content)
+    {
+        file_put_contents(resource_path('ts/index.ts'), $content);
+    }
+
     protected function getTranslationFilePath($language)
     {
         return resource_path('lang/' . $language . '.json');

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -183,4 +183,29 @@ class ExporterTest extends BaseTestCase
 
         $this->assertEquals($expected, $actual);
     }
+
+    public function testOverridePatterns()
+    {
+        $this->cleanLangsFolder();
+
+        $this->createTestView("{{ __('name') }}");
+        $this->createTestTypescript("__('name1')");
+
+        $this->artisan('translatable:export', [
+                'lang'      => 'bg,es',
+                '--patterns'  => '*.ts'
+            ])
+            ->expectsOutput('Translatable strings have been extracted and written to the bg.json file.')
+            ->expectsOutput('Translatable strings have been extracted and written to the es.json file.')
+            ->assertExitCode(0);
+
+        $this->assertFileExists($this->getTranslationFilePath('bg'));
+        $this->assertFileExists($this->getTranslationFilePath('es'));
+
+        $bg_content = $this->getTranslationFileContent('bg');
+        $es_content = $this->getTranslationFileContent('es');
+
+        $this->assertEquals(['name1' => 'name1'], $bg_content);
+        $this->assertEquals(['name1' => 'name1'], $es_content);
+    }
 }

--- a/tests/__fixtures/resources/ts/.gitignore
+++ b/tests/__fixtures/resources/ts/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Added option `--patterns` to override the default patterns for example when using a wrapper artisan command.