### PR TITLE
Support white space between parentheses and quotation marks in a translation function call

### DIFF
--- a/src/Core/CodeParser.php
+++ b/src/Core/CodeParser.php
@@ -16,7 +16,7 @@ class CodeParser
      *
      * @var string
      */
-    protected $pattern = '/([FUNCTIONS])\([\'"](.+)[\'"][\),]/U';
+    protected $pattern = '/([FUNCTIONS])\(\h?[\'"](.+)[\'"]\h?[\),]/U';
 
 
     /**


### PR DESCRIPTION
this ensures to support white space between the parenthesis and the quote. 
For example : 
__( 'Some Text' )