### PR TITLE
Update testTranslationFunctionNames to support white space between the parenthesis and the quote

### DIFF
--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -64,7 +64,7 @@ class ExporterTest extends BaseTestCase
 
         $this->cleanLangsFolder();
 
-        $this->createTestView("{{ __('name__') }} @lang('name_lang') {{ _t('name_t') }}");
+        $this->createTestView("{{ __('name__') }} @lang('name_lang') {{ _t('name_t') }} {{ __( 'name__' ) }} @lang( 'name_lang' ) {{ _t( 'name_t' ) }}");
 
         $this->artisan('translatable:export', ['lang' => 'es'])
             ->expectsOutput('Translatable strings have been extracted and written to the es.json file.')


### PR DESCRIPTION
- Updated `testTranslationFunctionNames` to includes tests to match the modification on the following PR https://github.com/kkomelin/laravel-translatable-string-exporter/pull/38#issuecomment-581266508