### PR TITLE
Fix Str class not found error for some Laravel configurations

### DIFF
--- a/src/Console/InspectTranslationsCommand.php
+++ b/src/Console/InspectTranslationsCommand.php
@@ -2,6 +2,7 @@
 namespace KKomelin\TranslatableStringExporter\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 use KKomelin\TranslatableStringExporter\Core\Exporter;
 use KKomelin\TranslatableStringExporter\Core\StringExtractor;
 use KKomelin\TranslatableStringExporter\Core\UntranslatedStringFinder;
@@ -89,7 +90,7 @@ class InspectTranslationsCommand extends Command
         // Display untranslated strings.
         $this->info(
             'Found ' . $count_untranslated . ' untranslated ' .
-            \Str::plural('string', $count_untranslated) . ' in the ' .
+            Str::plural('string', $count_untranslated) . ' in the ' .
             $language . '.json file:'
         );
         foreach ($untranslated_strings as $untranslated_string) {


### PR DESCRIPTION
PHP Error:  Class 'Str' not found in /vendor/kkomelin/laravel-translatable-string-exporter/src/Console/InspectTranslationsCommand.php on line 92

**From the package maintainer:**
The error only occurs for setups which don't have `Illuminate\Support\Str` alias in their Laravel configs: https://github.com/laravel/laravel/blob/master/config/app.php#L225