### PR TITLE
Introduce a configuration option to automatically add keys from persistent-strings file to translation files

### DIFF
--- a/config/laravel-translatable-string-exporter.php
+++ b/config/laravel-translatable-string-exporter.php
@@ -27,4 +27,8 @@ return [
     // by original strings (keys).
     // It helps navigate a translation file and detect possible duplicates.
     'sort-keys' => true,
+
+    // Indicates weather keys added to persistent-strings file should be added
+    // to translation file
+    'add-persistent-strings' => false,
 ];

--- a/src/Core/Exporter.php
+++ b/src/Core/Exporter.php
@@ -52,6 +52,9 @@ class Exporter
             IO::languageFilePath($base_path, self::PERSISTENT_STRINGS_FILENAME_WO_EXT);
         $persistent_strings = IO::readTranslationFile($persistent_strings_path);
 
+        //if enabled import persistent string to translation file
+        $new_strings = $this->addPersistentStringIfEnabled($new_strings, $persistent_strings);
+
         // Merge old an new translations preserving existing translations and persistent strings.
         $resulting_strings = $this->mergeStrings($new_strings, $existing_strings, $persistent_strings);
 
@@ -95,6 +98,21 @@ class Exporter
         }
 
         return $strings;
+    }
+
+    /**
+     * Also add keys from persistent-string file to new_string.
+     *
+     * @param array $new_strings
+     * @param array $persistent_strings
+     * @return array
+     */
+    protected function addPersistentStringIfEnabled($new_strings, $persistent_strings) {
+        if (config('laravel-translatable-string-exporter.add-persistent-strings', false)) {
+            $new_strings = array_merge($new_strings, array_combine($persistent_strings, $persistent_strings));
+        }
+
+        return $new_strings;
     }
 
     /**

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -255,4 +255,51 @@ class ExporterTest extends BaseTestCase
 
         $this->assertEquals($expected, $actual);
     }
+
+    public function testAlsoAddPersistentTranslations()
+    {
+        $this->app['config']->set('laravel-translatable-string-exporter.add-persistent-strings', true);
+
+        $this->cleanLangsFolder();
+
+        // 1. Create a translation file ourselves.
+
+        $existing_translations = [
+            'name1_en' => 'name1_es',
+            'name2_en' => 'name2_es',
+            'name3_en' => 'name3_es',
+        ];
+
+        $content = json_encode($existing_translations);
+
+        $this->writeToTranslationFile('es', $content);
+
+        // 2. Create a file with the keys of any strings which should persist and added to export file even if they are not contained in the views.
+
+        $persistentContent = json_encode(['name3_en', 'name5_en']);
+        $this->writeToTranslationFile(Exporter::PERSISTENT_STRINGS_FILENAME_WO_EXT, $persistentContent);
+
+        // 3. Create a test view only containing a new string and a string that also in persistent.
+
+        $this->createTestView("{{ __('name1_en') . __('name2_en') . __('name3_en') . __('name4_en') }}");
+
+        $this->artisan('translatable:export', ['lang' => 'es'])
+            ->expectsOutput('Translatable strings have been extracted and written to the es.json file.')
+            ->assertExitCode(0);
+
+        $actual = $this->getTranslationFileContent('es');
+
+        // The new and persistent, strings should be added. The rest should remain.
+
+        $expected = [
+            'name1_en' => 'name1_es',
+            'name2_en' => 'name2_es',
+            'name3_en' => 'name3_es',
+            'name4_en' => 'name4_en',
+            'name5_en' => 'name5_en',
+        ];
+
+        $this->assertEquals($expected, $actual);
+
+    }
 }


### PR DESCRIPTION
Added option to to add keys from persistent-strings file to the exported translation file.

This option allows us to keep all language files in sync. This removes the issue that we forget to add new 'persistent strings' to some language files.