### PR TITLE
Fix some parsing issues

### DIFF
--- a/src/Core/CodeParser.php
+++ b/src/Core/CodeParser.php
@@ -50,7 +50,7 @@ class CodeParser
         $strings = [];
 
         if(!preg_match_all($this->pattern, $file->getContents(), $matches)) {
-            return $strings;
+            return $this->clean($strings);
         }
 
         foreach ($matches[2] as $string) {
@@ -60,6 +60,22 @@ class CodeParser
         // Remove duplicates.
         $strings = array_unique($strings);
 
-        return $strings;
+        return $this->clean($strings);
+    }
+
+    /**
+     * Provide extra clean up step
+     * Used for instances of {{ __('We\'re amazing!') }}
+     * Without clean up: We\'re amazing!
+     * With clean up: We're amazing!
+     *
+     * @param array $strings
+     * @return array
+     */
+    public function clean(array $strings)
+    {
+        return array_map(function ($string){
+            return str_replace('\\\'', '\'', $string);
+        }, $strings);
     }
 }

--- a/src/Core/CodeParser.php
+++ b/src/Core/CodeParser.php
@@ -18,7 +18,7 @@ class CodeParser
      *
      * @var string
      */
-    protected $pattern = '/([FUNCTIONS])\(\h*[\'"](.+)[\'"]\h*[\),]/U';
+    protected $pattern = '/([FUNCTIONS])\(\h*([\'"])(.+)\2\h*[\),]/U';
 
 
     /**
@@ -53,7 +53,7 @@ class CodeParser
             return $this->clean($strings);
         }
 
-        foreach ($matches[2] as $string) {
+        foreach ($matches[3] as $string) {
             $strings[] = $string;
         }
 

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -134,9 +134,12 @@ class ExporterTest extends BaseTestCase
 
         $view = "{{ __('He said \"WOW\".') }} " .
             "{{ __('We\'re amazing!') }} " .
-            "@lang(\"You're pretty great!\") ";
+            "@lang(\"You're pretty great!\") " .
+            "@lang(\"You\"re pretty great!\") " .
+            "{{ __('Therefore, we automatically look for columns named something like \"Last name\", \"First name\", \"E-mail\" etc.') }}";
 
-        $this->createTestView($view);
+
+    $this->createTestView($view);
 
         $this->artisan('translatable:export', ['lang' => 'es'])
             ->expectsOutput('Translatable strings have been extracted and written to the es.json file.')
@@ -148,6 +151,8 @@ class ExporterTest extends BaseTestCase
             'He said "WOW".' => 'He said "WOW".',
             'You\'re pretty great!' => 'You\'re pretty great!',
             'We\'re amazing!' => 'We\'re amazing!',
+            'You"re pretty great!' => 'You"re pretty great!',
+            'Therefore, we automatically look for columns named something like "Last name", "First name", "E-mail" etc.' => 'Therefore, we automatically look for columns named something like "Last name", "First name", "E-mail" etc.'
         ];
 
         $this->assertEquals($expected, $actual);

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -93,6 +93,66 @@ class ExporterTest extends BaseTestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testQuotationMarkDelimiter()
+    {
+
+        $this->cleanLangsFolder();
+
+        $view = "{{ __(\"name__\") }} " .
+            "@lang(\"name_lang\") " .
+            "{{ _t(\"name_t\") }} " .
+            "{{ __(\"name__space_end\" ) }} " .
+            "@lang( \"name_lang_space_start\") " .
+            "{{ _t( \"name_t_space_both\" ) }} " .
+            "{{ _t(  \"name_t_double_space\"  ) }}";
+
+        $this->createTestView($view);
+
+        $this->artisan('translatable:export', ['lang' => 'es'])
+            ->expectsOutput('Translatable strings have been extracted and written to the es.json file.')
+            ->assertExitCode(0);
+
+        $actual = $this->getTranslationFileContent('es');
+
+        $expected = [
+            'name__' => 'name__',
+            'name_lang' => 'name_lang',
+            'name_t' => 'name_t',
+            'name__space_end' => 'name__space_end',
+            'name_lang_space_start' => 'name_lang_space_start',
+            'name_t_space_both' => 'name_t_space_both',
+            'name_t_double_space' => 'name_t_double_space',
+        ];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testMixedDelimiters()
+    {
+
+        $this->cleanLangsFolder();
+
+        $view = "{{ __('He said \"WOW\".') }} " .
+            "{{ __('We\'re amazing!') }} " .
+            "@lang(\"You're pretty great!\") ";
+
+        $this->createTestView($view);
+
+        $this->artisan('translatable:export', ['lang' => 'es'])
+            ->expectsOutput('Translatable strings have been extracted and written to the es.json file.')
+            ->assertExitCode(0);
+
+        $actual = $this->getTranslationFileContent('es');
+
+        $expected = [
+            'He said "WOW".' => 'He said "WOW".',
+            'You\'re pretty great!' => 'You\'re pretty great!',
+            'We\'re amazing!' => 'We\'re amazing!',
+        ];
+
+        $this->assertEquals($expected, $actual);
+    }
+
     public function testMultiLineSupportDisabled()
     {
         $this->cleanLangsFolder();


### PR DESCRIPTION
1. Escaped string delimiter characters were not removed. Therefore, the code snippet `{{ __('We\'re amazing!') }}` would end up as `We\'re amazing!` in the localization file. Expected behavior is `We're amazing!`
2. The regex rule does not require the string delimiters to be the same. 
This causes issues for e.g. `{{ __('Therefore, we automatically look for columns named something like "Last name", "First name", "E-mail" etc.') }}`. The current rule selects the closing quotation mark of "Last name". The expected behavior is that the hole string is recognized as such until the "closing" '