### PR TITLE
Support new lang folder structure

### DIFF
--- a/src/Core/Utils/IO.php
+++ b/src/Core/Utils/IO.php
@@ -2,6 +2,7 @@
 
 namespace KKomelin\TranslatableStringExporter\Core\Utils;
 
+use Exception;
 use KKomelin\TranslatableStringExporter\Core\Utils\JSON;
 
 /**
@@ -14,9 +15,12 @@ class IO
     /**
      * The target directory for translation files.
      *
-     * @var string
+     * @var array
      */
-    const TRANSLATION_FILE_DIRECTORY = 'resources/lang';
+    const TRANSLATION_FILE_DIRECTORIES = [
+        'lang',
+        'resources/lang',
+    ];
 
     /**
      * Write a string to a file.
@@ -62,8 +66,16 @@ class IO
      */
     public static function languageFilePath($base_path, $language)
     {
-        return $base_path . DIRECTORY_SEPARATOR .
-            self::TRANSLATION_FILE_DIRECTORY . DIRECTORY_SEPARATOR .
-            $language . '.json';
+        foreach (self::TRANSLATION_FILE_DIRECTORIES as $directory) {
+            $fileName = $base_path . DIRECTORY_SEPARATOR .
+                $directory . DIRECTORY_SEPARATOR .
+                $language . '.json';
+
+            if (file_exists($fileName)) {
+                return $fileName;
+            }
+        }
+
+        throw new Exception('Could not find files in folders: ' . implode(', ', self::TRANSLATION_FILE_DIRECTORIES));
     }
 }


### PR DESCRIPTION
Quick way of supporting the new folder structure - either `lang` (new) or `resources/lang` (pre Laravel 9).

See #60 for more info.