### PR TITLE
Rely on lang_path() and resource_path('lang') for getting the language file path

### DIFF
--- a/src/Core/Utils/IO.php
+++ b/src/Core/Utils/IO.php
@@ -55,13 +55,6 @@ class IO
      */
     public static function languageFilePath($base_path, $language)
     {
-        $translation_file_directory =
-            is_dir($base_path . DIRECTORY_SEPARATOR . 'resources/lang') 
-            ? 'resources/lang' 
-            : 'lang';
-
-        return $base_path . DIRECTORY_SEPARATOR .
-            $translation_file_directory . DIRECTORY_SEPARATOR .
-            $language . '.json';
+        return function_exists('lang_path') ? lang_path("$language.json") : resource_path("lang/$language.json");
     }
 }


### PR DESCRIPTION
Bit simpler as it just relies on Laravel's way to look up the language path.

- `lang_path()` if it exists (from the 8.x branch)
- Fallback to `resource_path('lang')`

This makes the `$base_path` obsolete. Haven'tremoved it yet, but will do in another PR.