### PR TITLE
Add PHP CS fixer action and format the code

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,0 +1,21 @@
+name: Check & fix styling
+
+on: [push]
+
+jobs:
+  php-cs-fixer:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run PHP CS Fixer
+        uses: docker://oskarstark/php-cs-fixer-ga
+        with:
+          args: --config=.php_cs.dist.php --allow-risky=yes
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Fix styling

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/
 composer.lock
 .DS_Store
 .phpunit.result.cache
+.php-cs-fixer.cache

--- a/.php_cs.dist.php
+++ b/.php_cs.dist.php
@@ -1,0 +1,40 @@
+<?php
+
+$finder = Symfony\Component\Finder\Finder::create()
+    ->in([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->name('*.php')
+    ->notName('*.blade.php')
+    ->ignoreDotFiles(true)
+    ->ignoreVCS(true);
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR12' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'no_unused_imports' => true,
+        'not_operator_with_successor_space' => true,
+        'trailing_comma_in_multiline' => true,
+        'phpdoc_scalar' => true,
+        'unary_operator_spaces' => true,
+        'binary_operator_spaces' => true,
+        'blank_line_before_statement' => [
+            'statements' => ['break', 'continue', 'declare', 'return', 'throw', 'try'],
+        ],
+        'phpdoc_single_line_var_spacing' => true,
+        'phpdoc_var_without_name' => true,
+        'class_attributes_separation' => [
+            'elements' => [
+                'method' => 'one',
+            ],
+        ],
+        'method_argument_space' => [
+            'on_multiline' => 'ensure_fully_multiline',
+            'keep_multiple_spaces_after_comma' => true,
+        ],
+        'single_trait_insert_per_statement' => true,
+    ])
+    ->setFinder($finder);

--- a/.php_cs.dist.php
+++ b/.php_cs.dist.php
@@ -36,5 +36,6 @@ return (new PhpCsFixer\Config())
             'keep_multiple_spaces_after_comma' => true,
         ],
         'single_trait_insert_per_statement' => true,
+        'visibility_required' => false,
     ])
     ->setFinder($finder);

--- a/src/Console/ExportCommand.php
+++ b/src/Console/ExportCommand.php
@@ -1,14 +1,13 @@
 <?php
+
 namespace KKomelin\TranslatableStringExporter\Console;
 
 use Illuminate\Console\Command;
 use KKomelin\TranslatableStringExporter\Core\Exporter;
-use KKomelin\TranslatableStringExporter\Core\StringExtractor;
 use Symfony\Component\Console\Input\InputArgument;
 
 class ExportCommand extends Command
 {
-
     /**
      * The console command name.
      *
@@ -79,7 +78,7 @@ class ExportCommand extends Command
             [
                 'lang',
                 InputArgument::REQUIRED,
-                'A language code or a comma-separated list of language codes for which the translatable strings are extracted, e.g. "es" or "es,bg,de".'
+                'A language code or a comma-separated list of language codes for which the translatable strings are extracted, e.g. "es" or "es,bg,de".',
             ],
         ];
     }

--- a/src/Console/InspectTranslationsCommand.php
+++ b/src/Console/InspectTranslationsCommand.php
@@ -1,16 +1,15 @@
 <?php
+
 namespace KKomelin\TranslatableStringExporter\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 use KKomelin\TranslatableStringExporter\Core\Exporter;
-use KKomelin\TranslatableStringExporter\Core\StringExtractor;
 use KKomelin\TranslatableStringExporter\Core\UntranslatedStringFinder;
 use Symfony\Component\Console\Input\InputArgument;
 
 class InspectTranslationsCommand extends Command
 {
-
     /**
      * The name and signature of the console command.
      *
@@ -82,11 +81,13 @@ class InspectTranslationsCommand extends Command
 
         if ($untranslated_strings === false) {
             $this->info('Did not find ' . $language . '.json file. Use --export-first option.');
+
             return;
         }
 
         if (empty($untranslated_strings)) {
             $this->info('Did not find any untranslated strings in the ' . $language . '.json file.');
+
             return;
         }
 
@@ -114,7 +115,7 @@ class InspectTranslationsCommand extends Command
             [
                 'lang',
                 InputArgument::REQUIRED,
-                'A language code for which untranslated strings are detected, e.g. "es".'
+                'A language code for which untranslated strings are detected, e.g. "es".',
             ],
         ];
     }

--- a/src/Core/CodeParser.php
+++ b/src/Core/CodeParser.php
@@ -20,18 +20,19 @@ class CodeParser
      */
     protected $pattern = '/([FUNCTIONS])\(\h*[\'"](.+)[\'"]\h*[\),]/U';
 
-
     /**
      * Parser constructor.
      */
     public function __construct()
     {
-        $this->functions = config('laravel-translatable-string-exporter.functions',
-           [
+        $this->functions = config(
+            'laravel-translatable-string-exporter.functions',
+            [
                '__',
                '_t',
-               '@lang'
-           ]);
+               '@lang',
+           ]
+        );
         $this->pattern = str_replace('[FUNCTIONS]', implode('|', $this->functions), $this->pattern);
 
         if (config('laravel-translatable-string-exporter.allow-newlines', false)) {
@@ -49,7 +50,7 @@ class CodeParser
     {
         $strings = [];
 
-        if(!preg_match_all($this->pattern, $file->getContents(), $matches)) {
+        if (! preg_match_all($this->pattern, $file->getContents(), $matches)) {
             return $strings;
         }
 

--- a/src/Core/Exporter.php
+++ b/src/Core/Exporter.php
@@ -14,7 +14,7 @@ class Exporter
      *
      * @var string
      */
-    public const PERSISTENT_STRINGS_FILENAME_WO_EXT = 'persistent-strings';
+    const PERSISTENT_STRINGS_FILENAME_WO_EXT = 'persistent-strings';
 
     /**
      * Extractor object.

--- a/src/Core/Exporter.php
+++ b/src/Core/Exporter.php
@@ -4,8 +4,8 @@ namespace KKomelin\TranslatableStringExporter\Core;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Lang;
-use KKomelin\TranslatableStringExporter\Core\Utils\JSON;
 use KKomelin\TranslatableStringExporter\Core\Utils\IO;
+use KKomelin\TranslatableStringExporter\Core\Utils\JSON;
 
 class Exporter
 {
@@ -14,7 +14,7 @@ class Exporter
      *
      * @var string
      */
-    const PERSISTENT_STRINGS_FILENAME_WO_EXT = 'persistent-strings';
+    public const PERSISTENT_STRINGS_FILENAME_WO_EXT = 'persistent-strings';
 
     /**
      * Extractor object.
@@ -80,6 +80,7 @@ class Exporter
     protected function mergeStrings($new_strings, $existing_strings, $persistent_strings)
     {
         $merged_strings = array_merge($new_strings, $existing_strings);
+
         return $this->arrayFilterByKey($merged_strings, function ($key) use ($persistent_strings, $new_strings) {
             return in_array($key, $persistent_strings) || array_key_exists($key, $new_strings);
         });
@@ -110,7 +111,8 @@ class Exporter
      * @param array $persistent_strings
      * @return array
      */
-    protected function addPersistentStringsIfEnabled($new_strings, $persistent_strings) {
+    protected function addPersistentStringsIfEnabled($new_strings, $persistent_strings)
+    {
         if (config('laravel-translatable-string-exporter.add-persistent-strings-to-translations', false)) {
             $new_strings = array_merge(
                 array_combine($persistent_strings, $persistent_strings),
@@ -129,7 +131,8 @@ class Exporter
      * @param string $language
      * @return array|mixed
      */
-    protected function excludeTranslationKeysIfEnabled($translatable_strings, $language) {
+    protected function excludeTranslationKeysIfEnabled($translatable_strings, $language)
+    {
         if (config('laravel-translatable-string-exporter.exclude-translation-keys', false)) {
             foreach ($translatable_strings as $key => $value) {
                 if ($this->isTranslationKey($key, $language)) {
@@ -150,7 +153,8 @@ class Exporter
      * @param array $translatable_strings
      * @return array
      */
-    protected function advancedSortIfEnabled($translatable_strings) {
+    protected function advancedSortIfEnabled($translatable_strings)
+    {
         // If it's necessary to put untranslated strings at the top.
         if (config('laravel-translatable-string-exporter.put-untranslated-strings-at-the-top', false)) {
             $translated = [];
@@ -158,6 +162,7 @@ class Exporter
             foreach ($translatable_strings as $key => $value) {
                 if ($key === $value) {
                     $untranslated[$key] = $value;
+
                     continue;
                 }
                 $translated[$key] = $value;
@@ -193,6 +198,7 @@ class Exporter
     private function arrayFilterByKey($array, $callback)
     {
         $matchedKeys = array_filter(array_keys($array), $callback);
+
         return array_intersect_key($array, array_flip($matchedKeys));
     }
 
@@ -204,8 +210,8 @@ class Exporter
      * @param string $locale
      * @return bool
      */
-    private function isTranslationKey($key, $locale) {
-
+    private function isTranslationKey($key, $locale)
+    {
         $dot_position = strpos($key, '.');
 
         // Ignore string without dots.
@@ -215,7 +221,7 @@ class Exporter
 
         // Ignore strings where the dot is at the end of a string
         // because it's a normal sentence.
-        if($dot_position === (strlen($key) - 1)) {
+        if ($dot_position === (strlen($key) - 1)) {
             return false;
         }
 
@@ -231,6 +237,6 @@ class Exporter
         // If the received translation is an array, the initial translation key is not full,
         // so we consider it wrong.
 
-        return isset($translations[$key]) && !is_array($translations[$key]);
+        return isset($translations[$key]) && ! is_array($translations[$key]);
     }
 }

--- a/src/Core/FileFinder.php
+++ b/src/Core/FileFinder.php
@@ -25,16 +25,20 @@ class FileFinder
      */
     public function __construct()
     {
-        $this->directories = config('laravel-translatable-string-exporter.directories',
+        $this->directories = config(
+            'laravel-translatable-string-exporter.directories',
             [
                 'app',
                 'resources',
-            ]);
-        $this->patterns = config('laravel-translatable-string-exporter.patterns',
+            ]
+        );
+        $this->patterns = config(
+            'laravel-translatable-string-exporter.patterns',
             [
                 '*.php',
-                '*.js'
-            ]);
+                '*.js',
+            ]
+        );
     }
 
     /**
@@ -47,7 +51,7 @@ class FileFinder
         $path = base_path();
 
         $directories = $this->directories;
-        array_walk($directories, function (&$item) use($path) {
+        array_walk($directories, function (&$item) use ($path) {
             $item = $path . DIRECTORY_SEPARATOR . $item;
         });
 

--- a/src/Core/StringExtractor.php
+++ b/src/Core/StringExtractor.php
@@ -25,7 +25,8 @@ class StringExtractor
      *
      * @return array
      */
-    public function extract() {
+    public function extract()
+    {
         $strings = [];
 
         $files = $this->finder->find();
@@ -42,8 +43,8 @@ class StringExtractor
      * @param array $strings
      * @return array
      */
-    protected function formatArray(array $strings) {
-
+    protected function formatArray(array $strings)
+    {
         $result = [];
 
         foreach ($strings as $string) {

--- a/src/Core/UntranslatedStringFinder.php
+++ b/src/Core/UntranslatedStringFinder.php
@@ -16,7 +16,7 @@ class UntranslatedStringFinder
     {
         $language_path = IO::languageFilePath($language);
 
-        if (!file_exists($language_path)) {
+        if (! file_exists($language_path)) {
             return false;
         }
 

--- a/src/Core/Utils/IO.php
+++ b/src/Core/Utils/IO.php
@@ -2,8 +2,6 @@
 
 namespace KKomelin\TranslatableStringExporter\Core\Utils;
 
-use KKomelin\TranslatableStringExporter\Core\Utils\JSON;
-
 /**
  * Class IO is responsible for reading from and writing to files.
  *
@@ -18,7 +16,8 @@ class IO
      * @param string $path
      * @return void
      */
-    public static function write($content, $path) {
+    public static function write($content, $path)
+    {
         file_put_contents($path, $content);
     }
 
@@ -28,9 +27,9 @@ class IO
      * @param string $path
      * @return string|bool
      */
-    public static function read($path) {
-
-        if (!file_exists($path)) {
+    public static function read($path)
+    {
+        if (! file_exists($path)) {
             return false;
         }
 
@@ -43,8 +42,10 @@ class IO
      * @param string $language_path
      * @return array
      */
-    public static function readTranslationFile($language_path) {
+    public static function readTranslationFile($language_path)
+    {
         $content = self::read($language_path);
+
         return JSON::jsonDecode($content);
     }
 

--- a/src/Providers/ExporterServiceProvider.php
+++ b/src/Providers/ExporterServiceProvider.php
@@ -3,11 +3,11 @@
 namespace KKomelin\TranslatableStringExporter\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use KKomelin\TranslatableStringExporter\Console\InspectTranslationsCommand;
 use KKomelin\TranslatableStringExporter\Console\ExportCommand;
+use KKomelin\TranslatableStringExporter\Console\InspectTranslationsCommand;
 
-class ExporterServiceProvider extends ServiceProvider {
-
+class ExporterServiceProvider extends ServiceProvider
+{
     /**
      * Indicates if loading of the provider is deferred.
      *
@@ -57,14 +57,14 @@ class ExporterServiceProvider extends ServiceProvider {
      */
     public function provides()
     {
-        return array(
+        return [
             'translatable-string-exporter-exporter',
             'command.translatable-string-exporter-exporter.export',
             'translatable-string-exporter-inspect-translations',
             'command.translatable-string-exporter-inspect-translations.inspect-translations',
-        );
+        ];
     }
-    
+
     /**
      * Perform post-registration booting of services.
      *

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -2,8 +2,8 @@
 
 namespace Tests;
 
-use Orchestra\Testbench\TestCase;
 use KKomelin\TranslatableStringExporter\Providers\ExporterServiceProvider;
+use Orchestra\Testbench\TestCase;
 
 class BaseTestCase extends TestCase
 {
@@ -53,6 +53,7 @@ class BaseTestCase extends TestCase
     {
         $path = $this->getTranslationFilePath($language);
         $content = file_get_contents($path);
+
         return json_decode($content, true);
     }
 

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -29,7 +29,6 @@ class ExporterTest extends BaseTestCase
 
     public function testTranslationSorting()
     {
-
         $this->removeJsonLanguageFiles();
 
         $source = [
@@ -61,7 +60,6 @@ class ExporterTest extends BaseTestCase
 
     public function testTranslationFunctionNames()
     {
-
         $this->removeJsonLanguageFiles();
 
         $view = "{{ __('name__') }} " .
@@ -329,7 +327,7 @@ class ExporterTest extends BaseTestCase
             'string with a dot.' => 'string with a dot.',
             'string with a dot. in the middle' => 'string with a dot. in the middle',
             'menu.unknown' => 'menu.unknown',
-            'menu.submenu1' => 'menu.submenu1'
+            'menu.submenu1' => 'menu.submenu1',
         ];
 
         $this->assertEquals($expected, $actual);

--- a/tests/UntranslatedStringFinderTest.php
+++ b/tests/UntranslatedStringFinderTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Tests;
+
 use Illuminate\Support\Str;
 
 class UntranslatedStringFinderTest extends BaseTestCase
@@ -39,7 +40,7 @@ class UntranslatedStringFinderTest extends BaseTestCase
         $language = 'es';
         $command = $this->artisan('translatable:inspect-translations', [
             'lang' => $language,
-            '--export-first' => true
+            '--export-first' => true,
         ])
             ->expectsOutput(
                 'Found ' . count($source) . ' untranslated ' .

--- a/tests/__fixtures/resources/lang/es/menu.php
+++ b/tests/__fixtures/resources/lang/es/menu.php
@@ -3,6 +3,6 @@
 return [
     'item1' => 'Item 1',
     'submenu1' => [
-        'item1' => 'Submenu 1: Item 1'
-    ]
+        'item1' => 'Submenu 1: Item 1',
+    ],
 ];


### PR DESCRIPTION
After working on the code, my editor kept formatting the files.

A suggestion I would not live without in my projects is PHP-cs-fixer. Its just cleaning up the code on push, and reformats whenever possible.

Down below is the changes, coming from a config files [again, by Spatie's skeleton package](https://github.com/spatie/package-skeleton-laravel/blob/main/.github/workflows/php-cs-fixer.yml). It's pretty much just common standards, but if there's something you don't like I can try to modify it.