### PR TITLE
Support custom transform functions

### DIFF
--- a/src/Core/CodeParser.php
+++ b/src/Core/CodeParser.php
@@ -6,111 +6,100 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class CodeParser
 {
-	/**
-	 * Translation function names.
-	 *
-	 * @var array
-	 */
-	protected $functions;
+    /**
+     * Translation function names.
+     *
+     * @var array
+     */
+    protected $functions;
 
-	/**
-	 * Translation function pattern.
-	 *
-	 * @var string|array
-	 */
-	protected $pattern = '/([FUNCTIONS])\(\s*([\'"])(?P<string>(?:(?![^\\\]\2).)+.)\2\s*[\),]/u';
+    /**
+     * Translation function pattern.
+     *
+     * @var string
+     */
+    protected $regexp = '/([FUNCTIONS])\(\s*([\'"])(?P<string>(?:(?![^\\\]\2).)+.)\2\s*[\),]/u';
 
-	/**
-	 * Parser constructor.
-	 *
-	 * @return void
-	 */
-	public function __construct()
-	{
-		$this->functions = config(
-			'laravel-translatable-string-exporter.functions',
-			[
-				'__',
-				'_t',
-				'@lang',
-			]
-		);
-		if (\Arr::isAssoc($this->functions)) {
-			$patterns = [];
-			foreach ($this->functions as $key => $value) {
-				if (\is_numeric($key)) {
-					$func     = $value;
-					$callable = null;
-				} else {
-					$func     = $key;
-					$callable = $value;
-				}
-				$patterns[str_replace('[FUNCTIONS]', $func, $this->pattern)] = $callable;
+    /**
+     * Translation function pattern.
+     *
+     * @var array
+     */
+    protected $patterns = [];
 
-				if (config('laravel-translatable-string-exporter.allow-newlines', false)) {
-					$patterns[$key] .= 's';
-				}
-			}
-			$this->pattern = $patterns;
-		} else {
-			$this->pattern = str_replace('[FUNCTIONS]', implode('|', $this->functions), $this->pattern);
+    /**
+     * Parser constructor.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->functions = config(
+            'laravel-translatable-string-exporter.functions',
+            [
+                '__',
+                '_t',
+                '@lang',
+            ]
+        );
 
-			if (config('laravel-translatable-string-exporter.allow-newlines', false)) {
-				$this->pattern .= 's';
-			}
-		}
-	}
+        foreach ($this->functions as $key => $value) {
+            if (\is_numeric($key)) {
+                $func     = $value;
+                $callable = null;
+            } else {
+                $func     = $key;
+                $callable = $value;
+            }
 
-	/**
-	 * Parse a file in order to find translatable strings.
-	 *
-	 * @return array
-	 */
-	public function parse(SplFileInfo $file)
-	{
-		$strings = [];
+            $pattern_key = str_replace('[FUNCTIONS]', $func, $this->regexp);
+            if (config('laravel-translatable-string-exporter.allow-newlines', false)) {
+                $pattern_key .= 's';
+            }
 
-		if (\is_array($this->pattern)) {
-			foreach ($this->pattern as $pattern => $func) {
-				preg_match_all($pattern, $file->getContents(), $matches);
+            $this->patterns[$pattern_key] = $callable;
+        }
+    }
 
-				foreach ($matches['string'] as $string) {
-					$strings[] = is_callable($func) ? $func($string) : $string;
-				}
-			}
+    /**
+     * Parse a file in order to find translatable strings.
+     *
+     * @return array
+     */
+    public function parse(SplFileInfo $file)
+    {
+        $strings = [];
 
-			// Remove duplicates.
-			$strings = array_unique($strings);
+        foreach ($this->patterns as $pattern => $func) {
+            preg_match_all($pattern, $file->getContents(), $matches);
 
-			return $this->clean($strings);
-		} else {
-			if (!preg_match_all($this->pattern, $file->getContents(), $matches)) {
-				return $this->clean($strings);
-			}
+            foreach ($matches['string'] as $string) {
+                if (\is_null($func)) {
+                    $strings[] = $string;
+                } elseif (\is_callable($func)) {
+                    $strings[] = $func($string);
+                }
+            }
+        }
 
-			foreach ($matches['string'] as $string) {
-				$strings[] = $string;
-			}
+        // Remove duplicates.
+        $strings = array_unique($strings);
 
-			// Remove duplicates.
-			$strings = array_unique($strings);
+        return $this->clean($strings);
+    }
 
-			return $this->clean($strings);
-		}
-	}
-
-	/**
-	 * Provide extra clean up step
-	 * Used for instances of {{ __('We\'re amazing!') }}
-	 * Without clean up: We\'re amazing!
-	 * With clean up: We're amazing!
-	 *
-	 * @return array
-	 */
-	public function clean(array $strings)
-	{
-		return array_map(function ($string) {
-			return str_replace('\\\'', '\'', $string);
-		}, $strings);
-	}
+    /**
+     * Provide extra clean up step
+     * Used for instances of {{ __('We\'re amazing!') }}
+     * Without clean up: We\'re amazing!
+     * With clean up: We're amazing!
+     *
+     * @return array
+     */
+    public function clean(array $strings)
+    {
+        return array_map(function ($string) {
+            return str_replace('\\\'', '\'', $string);
+        }, $strings);
+    }
 }

--- a/src/Core/CodeParser.php
+++ b/src/Core/CodeParser.php
@@ -64,7 +64,7 @@ class CodeParser
     /**
      * Parse a file in order to find translatable strings.
      *
-     * @param SplFileInfo $file
+     * @param  \Symfony\Component\Finder\SplFileInfo  $file
      * @return array
      */
     public function parse(SplFileInfo $file)

--- a/src/Core/CodeParser.php
+++ b/src/Core/CodeParser.php
@@ -64,6 +64,7 @@ class CodeParser
     /**
      * Parse a file in order to find translatable strings.
      *
+     * @param SplFileInfo $file
      * @return array
      */
     public function parse(SplFileInfo $file)
@@ -94,6 +95,7 @@ class CodeParser
      * Without clean up: We\'re amazing!
      * With clean up: We're amazing!
      *
+     * @param array $strings
      * @return array
      */
     public function clean(array $strings)

--- a/src/Core/CodeParser.php
+++ b/src/Core/CodeParser.php
@@ -14,14 +14,14 @@ class CodeParser
     protected $functions;
 
     /**
-     * Translation function pattern.
+     * Base search pattern.
      *
      * @var string
      */
-    protected $regexp = '/([FUNCTIONS])\(\s*([\'"])(?P<string>(?:(?![^\\\]\2).)+.)\2\s*[\),]/u';
+    protected $basePattern = '/([FUNCTIONS])\(\s*([\'"])(?P<string>(?:(?![^\\\]\2).)+.)\2\s*[\),]/u';
 
     /**
-     * Translation function pattern.
+     * Function-specific search patterns.
      *
      * @var array
      */
@@ -52,7 +52,7 @@ class CodeParser
                 $callable = $value;
             }
 
-            $pattern_key = str_replace('[FUNCTIONS]', $func, $this->regexp);
+            $pattern_key = str_replace('[FUNCTIONS]', $func, $this->basePattern);
             if (config('laravel-translatable-string-exporter.allow-newlines', false)) {
                 $pattern_key .= 's';
             }

--- a/src/Core/CodeParser.php
+++ b/src/Core/CodeParser.php
@@ -78,7 +78,7 @@ class CodeParser
                 if (\is_null($func)) {
                     $strings[] = $string;
                 } elseif (\is_callable($func)) {
-                    $strings[] = $func($string);
+                    $strings[] = call_user_func($func, $string);
                 }
             }
         }

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use KKomelin\TranslatableStringExporter\Core\Exporter;
+use Tests\__fixtures\classes\Transformer;
 
 class ExporterTest extends BaseTestCase
 {
@@ -509,6 +510,30 @@ EOD;
         $actual = $this->getTranslationFileContent('es');
         $expected = [
             'TEXT TO TRANSLATE' => 'TEXT TO TRANSLATE',
+        ];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testSettingACallableToTransform()
+    {
+        $this->app['config']->set('laravel-translatable-string-exporter.functions.staticMethod', [Transformer::class, 'staticMethod']);
+        $this->app['config']->set('laravel-translatable-string-exporter.functions.publicMethod', [new Transformer(), 'publicMethod']);
+
+        $this->removeJsonLanguageFiles();
+
+        $view = "{{ staticMethod('static-text-to-translate') }} {{ publicMethod('public-text-to-translate') }}";
+
+        $this->createTestView($view);
+
+        $this->artisan('translatable:export', ['lang' => 'es'])
+            ->expectsOutput('Translatable strings have been extracted and written to the es.json file.')
+            ->assertExitCode(0);
+
+        $actual = $this->getTranslationFileContent('es');
+        $expected = [
+            'STATIC TEXT TO TRANSLATE' => 'STATIC TEXT TO TRANSLATE',
+            'PUBLIC TEXT TO TRANSLATE' => 'PUBLIC TEXT TO TRANSLATE',
         ];
 
         $this->assertEquals($expected, $actual);

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -194,7 +194,7 @@ EOD;
             pushGenericFeedback(__(
                 "This is some generic key with a :var1 and :var2 in it 1",
                 ["var1" => "variable", "var2" => "another variable"]
-            ));      
+            ));
 
             pushGenericFeedback(
                 __("This is some generic key with a :var1 and :var2 in it 2",
@@ -490,5 +490,27 @@ EOD;
 
         // Check that arrays are equivalent taking into account element order.
         $this->assertTrue($expected === $actual, 'Expected and actual arrays are not equivalent.');
+    }
+
+    public function testSettingAFunctionToTransform()
+    {
+        $this->app['config']->set('laravel-translatable-string-exporter.functions.aFunction', fn ($s) => \strtoupper(\str_replace(["-","_"], " ", $s)));
+
+        $this->removeJsonLanguageFiles();
+
+        $view = "{{ aFunction('text-to-translate') }}";
+
+        $this->createTestView($view);
+
+        $this->artisan('translatable:export', ['lang' => 'es'])
+            ->expectsOutput('Translatable strings have been extracted and written to the es.json file.')
+            ->assertExitCode(0);
+
+        $actual = $this->getTranslationFileContent('es');
+        $expected = [
+            'TEXT TO TRANSLATE' => 'TEXT TO TRANSLATE',
+        ];
+
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/__fixtures/classes/Transformer.php
+++ b/tests/__fixtures/classes/Transformer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\__fixtures\classes;
+
+class Transformer
+{
+    public static function staticMethod($s)
+    {
+        return \strtoupper(\str_replace(["-","_"], " ", $s));
+    }
+
+    public function publicMethod($s)
+    {
+        return \strtoupper(\str_replace(["-","_"], " ", $s));
+    }
+};


### PR DESCRIPTION
with this is possible to use custom transforms in the config file IE
see #80 
```php
'functions' => [
    '__',
    '_t',
    '@lang',
    'make' => fn ($s) => \Str::of($s)->afterLast('.')->kebab()->replace(['-', '_'], ' ')->ucfirst(),
],
```

this is by no mean complete and can be simplified and refactored