### PR TITLE
Add EOL to updated .json files

### DIFF
--- a/src/Core/Utils/IO.php
+++ b/src/Core/Utils/IO.php
@@ -18,7 +18,7 @@ class IO
      */
     public static function write(string $content, string $path)
     {
-        file_put_contents($path, $content);
+        file_put_contents($path, $content . PHP_EOL);
     }
 
     /**


### PR DESCRIPTION
This PR makes it so the updated .json files add the EOL when saving the file.

Noticed when using the package inside a CI/CD pipeline that this happens:
![image](https://user-images.githubusercontent.com/13445515/224756141-7b7dc8b7-2d38-426f-9bc4-941c8be0de99.png)
