### PR TITLE
Add support for named parameters to __() and trans_choice()

### DIFF
--- a/src/Core/CodeParser.php
+++ b/src/Core/CodeParser.php
@@ -21,6 +21,13 @@ class CodeParser
     protected $basePattern = '/([FUNCTIONS])\(\s*([\'"])(?P<string>(?:(?![^\\\]\2).)+.)\2\s*[\),]/u';
 
     /**
+     * Named parameter search pattern for functions like trans_choice(key: 'string', ...).
+     *
+     * @var string
+     */
+    protected $namedParamPattern = '/([FUNCTIONS])\(\s*key:\s*([\'"])(?P<string>(?:(?![^\\\]\2).)+.)\2/u';
+
+    /**
      * Function-specific search patterns.
      *
      * @var array
@@ -53,12 +60,21 @@ class CodeParser
                 $callable = $value;
             }
 
+            // Add base pattern.
             $pattern_key = str_replace('[FUNCTIONS]', $func, $this->basePattern);
             if (config('laravel-translatable-string-exporter.allow-newlines', false)) {
                 $pattern_key .= 's';
             }
-
             $this->patterns[$pattern_key] = $callable;
+
+            // Add named parameter pattern for trans_choice and __ functions.
+            if (in_array($func, ['trans_choice', '__'])) {
+                $named_pattern = str_replace('[FUNCTIONS]', $func, $this->namedParamPattern);
+                if (config('laravel-translatable-string-exporter.allow-newlines', false)) {
+                    $named_pattern .= 's';
+                }
+                $this->patterns[$named_pattern] = $callable;
+            }
         }
     }
 

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -550,4 +550,50 @@ EOD;
 
         $this->assertEquals($expected, $actual);
     }
+
+    public function testNamedParameterSyntax()
+    {
+        $this->removeJsonLanguageFiles();
+
+        $view = "{{ trans_choice(key: 'One item|Many items', number: 1) }} " .
+            "{{ __(key: 'Simple message') }} " .
+            "{{ trans_choice(\n    key: 'Single line|Multiple lines',\n    number: 5,\n    replace: []\n) }} " .
+            "{{ __(key: 'Another message', replace: ['name' => 'John']) }}";
+
+        $this->createTestView($view);
+
+        $this->artisan('translatable:export', ['lang' => 'es'])
+            ->expectsOutput('Translatable strings have been extracted and written to the es.json file.')
+            ->assertExitCode(0);
+
+        $actual = $this->getTranslationFileContent('es');
+        $expected = [
+            'One item|Many items' => 'One item|Many items',
+            'Simple message' => 'Simple message',
+            'Single line|Multiple lines' => 'Single line|Multiple lines',
+            'Another message' => 'Another message',
+        ];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testExactNamedParameterPattern()
+    {
+        $this->removeJsonLanguageFiles();
+
+        $view = "{{ trans_choice(\n  key: 'Some string|Some strings',\n  number: 123,\n  replace: [],\n  locale: \n) }}";
+
+        $this->createTestView($view);
+
+        $this->artisan('translatable:export', ['lang' => 'es'])
+            ->expectsOutput('Translatable strings have been extracted and written to the es.json file.')
+            ->assertExitCode(0);
+
+        $actual = $this->getTranslationFileContent('es');
+        $expected = [
+            'Some string|Some strings' => 'Some string|Some strings',
+        ];
+
+        $this->assertEquals($expected, $actual);
+    }
 }


### PR DESCRIPTION
This pull request adds support for `__()` and `trans_choice()` when using named parameters.

For example:

```
__(key: 'Some string', locale: 'es_US');

__(
  key: 'Some string for :name',
  replace: ['name' => 'Joel'],
);

trans_choice(key: 'Some string|Some strings', number: 1, locale: 'es_US');

trans_choice(
  key: 'Some string for :name|Some strings for :name',
  number: 2,
  replace: ['name' => 'Joel'],
);
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds support for extracting translations when using named-parameter syntax (e.g., key: '...') in translation helpers, including __ and trans_choice.
  - Handles multiline and mixed-parameter scenarios to ensure keys are captured accurately.

- Tests
  - Introduces comprehensive tests for named-parameter usage, multiline cases, multiple parameters, and incomplete patterns to validate correct extraction behavior and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->